### PR TITLE
syntax error env_sauron -> env.sauron

### DIFF
--- a/sauron/utils.py
+++ b/sauron/utils.py
@@ -15,7 +15,7 @@ def get_mail_server():
     """
     mail_server = 'localhost'    
     if 'mail_server' in env.sauron['administrator']:
-        mail_server = env_sauron['administrator']['mail_server']
+        mail_server = env.sauron['administrator']['mail_server']
     return mail_server
 
 def send_mail(send_from, send_to, subject, text, files=[], html=False):


### PR DESCRIPTION
Fixes the error when a mail_server is defined in config

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/fabric/main.py", line 743, in main
    *args, **kwargs
  File "/usr/local/lib/python2.7/site-packages/fabric/tasks.py", line 409, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/usr/local/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/drupal7/sauron/sauron/drupal/update.py", line 58, in check_update
    utils.send_mail(env.sauron['administrator']['mail'], env.project['mail'], subject, body, [], True)
  File "/home/drupal7/sauron/sauron/utils.py", line 58, in send_mail
    server = get_mail_server()
  File "/home/drupal7/sauron/sauron/utils.py", line 18, in get_mail_server
    mail_server = env_sauron['administrator']['mail_server']
NameError: global name 'env_sauron' is not defined
```
